### PR TITLE
Fix a missing import and actually run the tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: Run tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip flake8
+        sudo apt install wget
+        wget https://github.com/lh3/miniprot/releases/download/v0.13/miniprot-0.13_x64-linux.tar.bz2
+        tar xvf miniprot-0.13_x64-linux.tar.bz2
+        cp miniprot-0.13_x64-linux/miniprot /usr/local/bin
+        rm -rf miniprot-0.13_x64-linux*
+        wget https://github.com/lh3/minimap2/releases/download/v2.28/minimap2-2.28_x64-linux.tar.bz2
+        tar xvf minimap2-2.28_x64-linux.tar.bz2
+        mv minimap2-2.28_x64-linux/k8  minimap2-2.28_x64-linux/paftools.js  minimap2-2.28_x64-linux/minimap2 /usr/local/bin
+        rm -rf minimap2-2.28_x64-linux*
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Install lifton
+      run: |
+        python -m pip install -e .
+    - name: Test with pytest
+      run: |
+        cd test && bash -xeu lifton_chr22_example.sh
+        

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Run tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "*" ]
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install lifton
       run: |
         python -m pip install -e .
-    - name: Test with pytest
+    - name: Test using example from test dir
       run: |
         cd test && bash -xeu lifton_chr22_example.sh
         

--- a/lifton/lifton.py
+++ b/lifton/lifton.py
@@ -1,4 +1,4 @@
-from lifton import mapping, intervals, lifton_utils, annotation, extract_sequence, stats, logger, run_liftoff, run_miniprot, run_evaluation, __version__
+from lifton import intervals, lifton_utils, annotation, extract_sequence, stats, logger, run_liftoff, run_miniprot, run_evaluation, __version__
 from intervaltree import Interval
 import argparse
 from pyfaidx import Fasta


### PR DESCRIPTION
Hello,

Lifton seems a promising tool, however there is a bug that prevents execution: the code imports a module that doesn't exist ([`lifton.mapping`](https://github.com/Kuanhao-Chao/LiftOn/compare/main...kdm9:bugfixes?expand=1#diff-c1677e30232266677706cfb649abb7287d76a0554e14a6cfad7bde64adeb5adeR1)).

I've fixed that, but I've also added a github action config to run the example/test you have, which would have caught this issue when it was first made. Strangely installing from pip seems to work alright, but there is another bug I'm trying to track down, and after installing from git with `pip install -e .`, lifton doesn't work.

best,
Kevin